### PR TITLE
envirment  variable to populate a htpassword file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,10 @@ if [ "$1" = 'oauth2_proxy' -a "$(id -u)" = '0' ]; then
     exec su-exec oauth2_proxy "$0" "$@"
 fi
 
+if [ ! -z ${HTACCESS} ]; then
+    echo "${HTACCESS}" >> /conf/htaccess
+fi
+
 if [ "$1" = 'oauth2_proxy' ]; then
     # if no configfile is provided, generate one based on the environment variables
     if [ ! -f /conf/oauth2_proxy.cfg ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,7 @@ if [ "$1" = 'oauth2_proxy' -a "$(id -u)" = '0' ]; then
     exec su-exec oauth2_proxy "$0" "$@"
 fi
 
+# populate htpasswd file with SHA hash
 if [ ! -z ${HTPASSWD} ]; then
     echo "${HTPASSWD}" >> /conf/htpasswd
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,8 +11,8 @@ if [ "$1" = 'oauth2_proxy' -a "$(id -u)" = '0' ]; then
     exec su-exec oauth2_proxy "$0" "$@"
 fi
 
-if [ ! -z ${HTACCESS} ]; then
-    echo "${HTACCESS}" >> /conf/htaccess
+if [ ! -z ${HTPASSWD} ]; then
+    echo "${HTPASSWD}" >> /conf/htpasswd
 fi
 
 if [ "$1" = 'oauth2_proxy' ]; then


### PR DESCRIPTION
Hi! 

Would you be willing to add a feature like this, which would allow you to pass content to a htpassword file?  I'm trying to enable both Oauth for our users, as well as basic auth for some of our automation which doesn't support Oauth on ECS, and being able to pass the content of the HTPASSWD file via env var makes life much easier... 