### PR TITLE
Use oauth2_proxy version 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supported tags and respective `Dockerfile` links
 
-- `2`, `2.2`, `2.1`, `latest` [(Dockerfile)](https://github.com/machine-data/docker-oauth2_proxy/blob/master/Dockerfile)
+- `2`, `2.1`, `2.2`, `latest` [(Dockerfile)](https://github.com/machine-data/docker-oauth2_proxy/blob/master/Dockerfile)
 
 # oauth2_proxy on Docker
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # oauth2_proxy on Docker
 
 This repository holds a build definition and supporting files for building a Docker image to run [oauth2_proxy](https://github.com/bitly/oauth2_proxy).
-It is published as automated build `machine-data/oauth2_proxy` on [Docker Hub](https://registry.hub.docker.com/u/machinedata/oauth2_proxy/).
+It is published as automated build `machinedata/oauth2_proxy` on [Docker Hub](https://registry.hub.docker.com/u/machinedata/oauth2_proxy/).
 
 ## What is oauth2_proxy?
 
@@ -30,7 +30,7 @@ $ docker run -d -p 4180:4180 \
     -e OAUTH2_PROXY_CLIENT_ID=... \
     -e OAUTH2_PROXY_CLIENT_SECRET=... \
     -e OAUTH2_PROXY_UPSTREAM=... \
-    machine-data/oauth2_proxy
+    machinedata/oauth2_proxy
 ```
 
 ## Environment variables
@@ -101,7 +101,7 @@ $ mv oauth2_proxy.cfg.example oauth2_proxy.cfg
 $ sed -i -e "s/# http_address = .*/http_address = \"0.0.0.0:4180\"/" oauth2_proxy.cfg.example
 $ docker run -d \
              -v $(pwd)/oauth2_proxy.cfg.example:/config/oauth2_proxy.cfg:ro \
-             -p 4180:4180 machine-data/oauth2_proxy
+             -p 4180:4180 machinedata/oauth2_proxy
 ```
 
 ## Volumes

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,6 +50,7 @@ if [ "$1" = 'oauth2_proxy' ]; then
             pass-access-token
             pass-basic-auth
             pass-host-header
+            pass-user-headers
             profile-url
             provider
             proxy-prefix
@@ -60,7 +61,9 @@ if [ "$1" = 'oauth2_proxy' ]; then
             scope
             signature-key
             skip-auth-regex
+            skip-auth-preflight
             skip-provider-button
+            ssl-insecure-skip-verify
             tls-cert
             tls-key
             upstream


### PR DESCRIPTION
There has been a new release and I would like to have this included in this docker image.

I have included the new command line switches from the [release notes for 2.2](https://github.com/bitly/oauth2_proxy/releases/tag/v2.2).

Any comments are welcome!